### PR TITLE
Socket file permissions check for 766

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ Cargo.lock
 /*.elf
 /prepare_dependencies.sh
 /redbpf.patch
+
+/.vscode
+
+# Idea project files
+.idea
+*.iml


### PR DESCRIPTION
when I ran it on trace server:
```
# firewall:
sudo ./target/debug/firewall --device ens18

# node:
./run.sh release
```

I get:
```
ConnectionError { reason: Os { code: 13, kind: PermissionDenied, message: "Permission denied" } }
```

```
dev@trace:~/tezedge$ ls -lrt /tmp/tezedge_firewall.sock
srwxr-xr-x 1 root root 0 Dec  1 14:02 /tmp/tezedge_firewall.sock
```

after, this fix it works:
```
dev@trace:~/tezedge$ ls -lrt /tmp/tezedge_firewall.sock
srwxrw-rw- 1 root root 0 Dec  2 13:51 /tmp/tezedge_firewall.sock
```

